### PR TITLE
Moved checkBookingOverlap(...) from SearchResource to DriveResource

### DIFF
--- a/src/main/java/se/lth/base/server/rest/DriveResource.java
+++ b/src/main/java/se/lth/base/server/rest/DriveResource.java
@@ -9,8 +9,8 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 @Path("drive")
@@ -108,10 +108,15 @@ public class DriveResource {
     @Consumes(MediaType.APPLICATION_JSON + ";charset=utf-8")
     public DriveUser addUserToDrive(@PathParam("driveId") int driveId, DriveUser driveUser) {
         if (driveDao.getDrive(driveId).getCarNumberOfSeats() > driveUserDao.getNumberOfUsersInDrive(driveId)) {
-            return driveUserDao.addDriveUser(driveId, user.getId(), driveUser.getStart(), driveUser.getStop(), !IS_DRIVER, !IS_ACCEPTED, !IS_RATED);
+            List<Drive> collidingDrives = checkBookingOverlap(driveId, driveUser.getStart(), driveUser.getStop());
+            if (collidingDrives.isEmpty()) {
+                return driveUserDao.addDriveUser(driveId, user.getId(), driveUser.getStart(), driveUser.getStop(), !IS_DRIVER, !IS_ACCEPTED, !IS_RATED);
+            } else {
+                throw new WebApplicationException("This drive overlaps in time with other booked drives", Status.PRECONDITION_FAILED);
+            }
+        } else {
+            throw new WebApplicationException("No available seats left", Status.PRECONDITION_FAILED);
         }
-
-        throw new WebApplicationException("No available seats left", Status.PRECONDITION_FAILED);
     }
 
     @Path("{driveId}/user/{userId}")
@@ -209,5 +214,88 @@ public class DriveResource {
             List<DriveReport> reports = driveReportDao.getDriveReportsForDrive(d.getDriveId());
             driveWraps.add(new DriveWrap(d, milestones, users, reports));
         }
+    }
+
+    /**
+     * Checks if it is possible for a user to book a specific Drive.
+     *
+     * @param driveId the id of the drive that one wishes to see if it is possible to book
+     * @param start   at what milestone the user will be starting at
+     * @param stop    at what milestone the user will stop at
+     * @return a list of drives associated with this user, conflicting with the entered drive
+     */
+    private List<Drive> checkBookingOverlap(@PathParam("driveId") int driveId, @PathParam("start") String start, @PathParam("stop") String stop) {
+        Drive drive = driveDao.getDrive(driveId);
+        List<DriveMilestone> driveMilestones = driveMilestoneDao.getMilestonesForDrive(driveId);
+        // Add drive start and stop as milestones to list
+        driveMilestones.add(0, new DriveMilestone(-1, -1, drive.getStart(), drive.getDepartureTime()));
+        driveMilestones.add(new DriveMilestone(-1, -1, drive.getStop(), drive.getArrivalTime()));
+
+        // Find the time that the user would be busy if user participated in drive
+        long busyTimeStart = -1;
+        long busyTimeEnd = -1;
+
+        for (DriveMilestone dm : driveMilestones) {
+            if (dm.getMilestone().toLowerCase().trim().equals(start.toLowerCase().trim())) {
+                busyTimeStart = dm.getDepartureTime();
+            } else if (dm.getMilestone().toLowerCase().trim().equals(stop.toLowerCase().trim())) {
+                busyTimeEnd = dm.getDepartureTime();
+            }
+        }
+
+        // Check for time conflicts with other already booked drives/trips
+        List<Drive> associatedDrives = getDriveAssociatedWithUser(user.getId());
+        Iterator<Drive> driveIterator = associatedDrives.iterator();
+        while (driveIterator.hasNext()) {
+            Drive d = driveIterator.next();
+            List<DriveMilestone> tempDriveMilestones = driveMilestoneDao.getMilestonesForDrive(d.getDriveId());
+            // Add drive start and stop as milestones to list
+            tempDriveMilestones.add(0, new DriveMilestone(-1, -1, d.getStart(), d.getDepartureTime()));
+            tempDriveMilestones.add(new DriveMilestone(-1, -1, d.getStop(), d.getArrivalTime()));
+
+            // Find the time that the user is busy in this drive
+            long tempBusyTimeStart = -1;
+            long tempBusyTimeEnd = -1;
+
+            DriveUser driveUser = driveUserDao.getDriveUser(d.getDriveId(), user.getId());
+
+            for (DriveMilestone dm : tempDriveMilestones) {
+                if (dm.getMilestone().toLowerCase().trim().equals(driveUser.getStart().toLowerCase().trim())) {
+                    tempBusyTimeStart = dm.getDepartureTime();
+                } else if (dm.getMilestone().toLowerCase().trim().equals(driveUser.getStop().toLowerCase().trim())) {
+                    tempBusyTimeEnd = dm.getDepartureTime();
+                }
+            }
+
+            if (tempBusyTimeEnd < busyTimeStart || tempBusyTimeStart > busyTimeEnd) {
+                // No conflict
+                driveIterator.remove();
+            }
+        }
+
+        // Return all booked drives that are in conflict with the new booking
+        return associatedDrives;
+    }
+
+    private List<Drive> getDriveAssociatedWithUser(int userId) {
+        List<Drive> drives = driveDao.getDrives();
+        Iterator<Drive> iterator = drives.iterator();
+        while (iterator.hasNext()) {
+            Drive drive = iterator.next();
+            List<DriveUser> driveUsers = driveUserDao.getDriveUsersForDrive(drive.getDriveId());
+            for (int i = 0; i < driveUsers.size(); i++) {
+                DriveUser driveUser = driveUsers.get(i);
+                if (driveUser.getUserId() == userId) {
+                    // User is associated with this drive, keep drive in list
+                    break;
+                }
+                if (i + 1 == driveUsers.size()) {
+                    // User is not associated with this drive, remove drive from list
+                    iterator.remove();
+                }
+            }
+
+        }
+        return drives;
     }
 }

--- a/src/main/java/se/lth/base/server/rest/SearchResource.java
+++ b/src/main/java/se/lth/base/server/rest/SearchResource.java
@@ -27,7 +27,7 @@ public class SearchResource {
     private final MailHandler mailHandler = new MailHandler();
     private final User user;
 
-    // A trip with departure time within interval 13.00-13.10 will match drive milestone with departure time 13.10
+    // A trip with departure time within interval 13.00-14.00 will match drive milestone with departure time 14.00
     private final int SEARCH_MINUTES_MARGIN = 60;
 
     public SearchResource(@Context ContainerRequestContext context) {
@@ -164,93 +164,6 @@ public class SearchResource {
                 }
             }
         }
-    }
-
-    /**
-     * Checks if it is possible for a user to book a specific Drive.
-     *
-     * @param driveId the id of the drive that one wishes to see if it is possible to book
-     * @param start   at what milestone the user will be starting at
-     * @param stop    at what milestone the user will stop at
-     * @return a list of drives associated with this user, conflicting with the entered drive
-     */
-    @Path("checkbookingoverlap/{driveId}/{start}/{stop}")
-    @GET
-    @RolesAllowed(Role.Names.USER)
-    @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
-    public List<Drive> checkBookingOverlap(@PathParam("driveId") int driveId, @PathParam("start") String start, @PathParam("stop") String stop) {
-        Drive drive = driveDao.getDrive(driveId);
-        List<DriveMilestone> driveMilestones = driveMilestoneDao.getMilestonesForDrive(driveId);
-        // Add drive start and stop as milestones to list
-        driveMilestones.add(0, new DriveMilestone(-1, -1, drive.getStart(), drive.getDepartureTime()));
-        driveMilestones.add(new DriveMilestone(-1, -1, drive.getStop(), drive.getArrivalTime()));
-
-        // Find the time that the user would be busy if user participated in drive
-        long busyTimeStart = -1;
-        long busyTimeEnd = -1;
-
-        for (DriveMilestone dm : driveMilestones) {
-            if (dm.getMilestone().toLowerCase().trim().equals(start.toLowerCase().trim())) {
-                busyTimeStart = dm.getDepartureTime();
-            } else if (dm.getMilestone().toLowerCase().trim().equals(stop.toLowerCase().trim())) {
-                busyTimeEnd = dm.getDepartureTime();
-            }
-        }
-
-        // Check for time conflicts with other already booked drives/trips
-        List<Drive> associatedDrives = getDriveAssociatedWithUser(user.getId());
-        Iterator<Drive> driveIterator = associatedDrives.iterator();
-        while (driveIterator.hasNext()) {
-            Drive d = driveIterator.next();
-            List<DriveMilestone> tempDriveMilestones = driveMilestoneDao.getMilestonesForDrive(d.getDriveId());
-            // Add drive start and stop as milestones to list
-            tempDriveMilestones.add(0, new DriveMilestone(-1, -1, d.getStart(), d.getDepartureTime()));
-            tempDriveMilestones.add(new DriveMilestone(-1, -1, d.getStop(), d.getArrivalTime()));
-
-            // Find the time that the user is busy in this drive
-            long tempBusyTimeStart = -1;
-            long tempBusyTimeEnd = -1;
-
-            DriveUser driveUser = driveUserDao.getDriveUser(d.getDriveId(), user.getId());
-
-            for (DriveMilestone dm : tempDriveMilestones) {
-                if (dm.getMilestone().toLowerCase().trim().equals(driveUser.getStart().toLowerCase().trim())) {
-                    tempBusyTimeStart = dm.getDepartureTime();
-                } else if (dm.getMilestone().toLowerCase().trim().equals(driveUser.getStop().toLowerCase().trim())) {
-                    tempBusyTimeEnd = dm.getDepartureTime();
-                }
-            }
-
-            if (tempBusyTimeEnd < busyTimeStart || tempBusyTimeStart > busyTimeEnd) {
-                // No conflict
-                driveIterator.remove();
-            }
-        }
-
-        // Return all booked drives that are in conflict with the new booking
-        return associatedDrives;
-    }
-
-    private List<Drive> getDriveAssociatedWithUser(int userId) {
-        List<Drive> drives = driveDao.getDrives();
-        Iterator<Drive> iterator = drives.iterator();
-        while (iterator.hasNext()) {
-            Drive drive = iterator.next();
-            List<DriveUser> driveUsers = driveUserDao.getDriveUsersForDrive(drive.getDriveId());
-            for (int i = 0; i < driveUsers.size(); i++) {
-                DriveUser driveUser = driveUsers.get(i);
-                if (driveUser.getUserId() == userId) {
-                    // User is associated with this drive, keep drive in list
-                    break;
-                }
-                if (i + 1 == driveUsers.size()) {
-                    // User is not associated with this drive, remove drive from list
-                    iterator.remove();
-                }
-            }
-
-        }
-        return drives;
     }
 
     private List<Drive> filterDrivesMatchingTrip(String tripStart, String tripStop, Timestamp departureTime) {

--- a/src/test/java/se/lth/base/server/rest/SearchResourceTest.java
+++ b/src/test/java/se/lth/base/server/rest/SearchResourceTest.java
@@ -284,40 +284,4 @@ public class SearchResourceTest extends BaseResourceTest {
 
     }
     */
-
-    /**
-     * Make long booking 2018-10-20 12.00 - 18.00
-     * Try to att user to drive 1 (2018-10-20 12.00-12.30)
-     * Should be conflict
-     */
-    @Test
-    public void bookingOverlap() {
-        // Data access objects
-        DriveDataAccess driveDao = new DriveDataAccess(Config.instance().getDatabaseDriver());
-        DriveMilestoneDataAccess driveMilestoneDao = new DriveMilestoneDataAccess(Config.instance().getDatabaseDriver());
-        DriveUserDataAccess driveUserDao = new DriveUserDataAccess(Config.instance().getDatabaseDriver());
-
-        // Create long lasting drive
-        // Drive 4
-        long timestamp4 = new Timestamp(2018 - 1900, 10, 20, 12, 0, 0, 0).getTime();
-        long timestamp4_2 = new Timestamp(2018 - 1900, 10, 20, 18, 0, 0, 0).getTime();
-        Drive drive4 = driveDao.addDrive(new Drive(-1, "A", "F", timestamp4, timestamp4_2, "Comment", "x", "x", "x", "x", 1, 1, false, false, false));
-        int drive4Id = drive4.getDriveId();
-        long timestamp4_1 = new Timestamp(2018 - 1900, 10, 20, 12, 30, 0, 0).getTime();
-        driveMilestoneDao.addMilestone(drive4Id, "B", timestamp4_1);
-
-        // Add user to long lasting drive
-        driveUserDao.addDriveUser(drive4Id, user3Id, "A", "B", false, false, false);
-
-        login(SEARCH_TEST_CREDENTIALS_1);
-
-        // Check for overlaps
-        // We actually receive a List<LinkedTreeMap<String, Object>>
-        List<Drive> response = target("search")
-                .path("checkbookingoverlap/" + drive1Id + "/A/C")
-                .request()
-                .get(List.class);
-
-        Assert.assertEquals(1, response.size());
-    }
 }


### PR DESCRIPTION
Moved checkBookingOverlap(...) from SearchResource to DriveResource. checkBookingOverlap(...) is now a private method, and therefore cannot be tested directly. Moved getDrivesAssociatedWithUser(int) = helper method to checkBookingOverlap(...).

Fixes #196